### PR TITLE
Fixed PKGBUILD to correctly support custom package name

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -12,7 +12,7 @@ license=('{{.License}}')
 makedepends=('go' 'git')
 
 source=(
-	"{{.RepoUrl}}"{{range .Files}}
+	"{{.PkgName}}::{{.RepoUrl}}"{{range .Files}}
 	"{{.Name}}"{{end}}
 )
 


### PR DESCRIPTION
Without that if you try to specify custom name, you will get errors like 

```
==> Starting pkgver()...
/home/persienko/dev/tmp/makes/build/PKGBUILD: line 21: cd: /home/persienko/dev/tmp/makes/build/src/deployer: No such file or directory
==> Starting build()...
/home/persienko/dev/tmp/makes/build/PKGBUILD: line 26: cd: /home/persienko/dev/tmp/makes/build/src/deployer: No such file or directory
==> ERROR: A failure occurred in build().
    Aborting...
```
