### PR TITLE
Fixed symlink madness

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -33,6 +33,11 @@ pkgver() {
 build() {
 	cd "$srcdir/$pkgname"
 
+	if [ -L "$srcdir/$pkgname" ]; then
+		rm "$srcdir/$pkgname" -rf
+		mv "$srcdir/.go/src/$pkgname/" "$srcdir/$pkgname"
+	fi
+
 	rm -rf "$srcdir/.go/src"
 
 	mkdir -p "$srcdir/.go/src"


### PR DESCRIPTION
This fixes `Too many levels of symbolic links` error in every second build