### PR TITLE
remove literal slash

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 		files = append(files, pkgFile{
 			Name: serviceName,
 			Path: filepath.Join(
-				"/usr/lib/systemd/system/",
+				"usr/lib/systemd/system/",
 				serviceName,
 			),
 			Hash: hash,


### PR DESCRIPTION
fix for 
```
        install -DT -m0755 "$srcdir/sould.service" "$pkgdir//usr/lib/systemd/system/sould.service"
```