### PR TITLE
pkgbuild: Set the git protocol explicitly in source URL.

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ Options:
   -l <LICENSE>  License to use [default: GPL].
   -r <PKGREL>   Specify package release number [default: 1].
   -d <DIR>      Directory to place PKGBUILD [default: build].
-  -o <NAME>     File to write PKGBULD [default: PKGBUILD].
+  -o <NAME>     File to write PKGBUILD [default: PKGBUILD].
   -m <NAME>     Specify maintainer$MAINTAINER.
   -p <VAR>      Pass pkgver to specified global variable using ldflags.
   -D <LIST>     Comma-separated list of runtime package dependencies (depends).

--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -22,7 +22,7 @@ makedepends=(
 )
 
 source=(
-	"$_pkgname::{{.RepoURL}}#branch=${BRANCH:-master}"{{range .Files}}
+	"$_pkgname::git+{{.RepoURL}}#branch=${BRANCH:-master}"{{range .Files}}
 	"{{.Name}}"{{end}}
 )
 


### PR DESCRIPTION
This allows to clone directly from https URLs.

Fixes this issue when cloning using github URLs:

```
LANG=C go-makepkg -B  restic https://github.com/restic/restic
...
==> Starting pkgver()...
/home/juergen/tmp/build/PKGBUILD: line 33: cd: /home/juergen/tmp/build/src/restic: Not a directory
```
^^^ the HTTPS redirect document is stored as source.