### PR TITLE
pkgbuild: fail build if installation of binaries failed

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -78,9 +78,10 @@ build() {
 }
 
 package() {
-	find "$srcdir/go/bin/" -type f -executable | while read filename; do
-		install -DT "$filename" "$pkgdir/usr/bin/$(basename $filename)"
-	done{{range .Files}}
+	find "$srcdir/go/bin/" -type f -executable -execdir \
+		install -DT "{}" "$pkgdir/usr/bin/{}" ";"
+
+	{{range .Files}}
 	install -DT -m0755 "$srcdir/{{.Name}}" "$pkgdir/{{.Path}}"{{end}}
 }
 `))


### PR DESCRIPTION
Previously the package() succeded  and created an empty archive because `pipefail` is not enabled by
default in makepkg.

```
→ LANG=C go-makepkg -B "Restic rest server" https://github.com/restic/rest-server
...
==> Starting package()...
find: '/home/juergen/tmp/foo/build/src/go/bin/': No such file or directory
...
==> Creating package "rest-server"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: rest-server 20210104.285_a659f3d-1 (Sun Jan 17 17:01:25 2021)
```

With this commit:
```
...
==> Starting package()...
find: '/home/juergen/tmp/build/src/go/bin/': No such file or directory
==> ERROR: A failure occurred in package().
    Aborting...
```